### PR TITLE
Add commented-out flycheck-credo config

### DIFF
--- a/flycheck-config.el
+++ b/flycheck-config.el
@@ -8,4 +8,12 @@
 
 (use-package flycheck)
 
+;; make sure you have credo installed and then uncomment flycheck-credo-setup
+;; (use-package flycheck-credo)
+
+;; (eval-after-load 'flycheck
+;;   '(flycheck-credo-setup))
+
+;; (add-hook 'elixir-mode-hook 'flycheck-mode)
+
 (provide 'flycheck-config)


### PR DESCRIPTION
This makes it easy to use flycheck integration with credo once the external dependency has been installed.